### PR TITLE
Fix: Check for u32 first so positive numbers don't get trapped by i32

### DIFF
--- a/Tasks/Conflicts/code_scenario3.rs
+++ b/Tasks/Conflicts/code_scenario3.rs
@@ -31,14 +31,14 @@ fn main() {
     let input = &args[1]; // The input string to be parsed
 
     // Try parsing input as i32
-    if let Ok(value) = input.parse::<i32>() {
-        println!("{value} is of type i32: {} bytes", mem::size_of::<i32>());
-        print_other_types("i32");
-    }
-    // Try parsing input as u32
-    else if let Ok(value) = input.parse::<u32>() {
+    if let Ok(value) = input.parse::<u32>() {
         println!("{value} is of type u32: {} bytes", mem::size_of::<u32>());
         print_other_types("u32");
+    }
+    // Try parsing input as u32
+    else if let Ok(value) = input.parse::<i32>() {
+        println!("{value} is of type i32: {} bytes", mem::size_of::<i32>());
+        print_other_types("i32");
     }
     // Try parsing input as f64
     else if let Ok(value) = input.parse::<f64>() {


### PR DESCRIPTION
check if the type is unsigned integer before checking for signed integer as positive number which is unsigned never gets return as of type unsigned and we are checking the i32 condition making the u32 condition never to be reached